### PR TITLE
feat(ci): add deployment check and update README

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'Windsland52' && github.event.head_commit.author.email != '41898282+github-actions[bot]@users.noreply.github.com' }}
     runs-on: ubuntu-latest
     steps:
       - name: 检出代码

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 基于 Vue 3 + Naive UI + Tauri 的 MAAFramework 日志分析工具。
 
+🌍尝试网页版： [https://maaloganalyzer.maafw.xyz](https://maaloganalyzer.maafw.xyz)
+
+🚀下载到本地：[Release](https://github.com/Windsland52/MAALogAnalyzer/releases/latest)
+
 ## 📸 界面预览
 
 ### 主要功能界面


### PR DESCRIPTION
## Summary by Sourcery

更新项目文档以包含访问链接，并限制 GitHub Pages 部署工作流程，仅对来自主仓库所有者且作者不是机器人的提交运行。

CI：
- 为 GitHub Pages 部署工作流程添加保护，使其仅在提交作者为仓库所有者且不是 GitHub Actions 机器人时执行。

文档：
- 在 README 中添加指向托管网页演示和最新可下载发行版的直接链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update project documentation with access links and restrict the GitHub Pages deployment workflow to run only for commits from the main repository owner and non-bot authors.

CI:
- Guard the GitHub Pages deployment workflow so it only executes for commits authored by the repository owner and not by the GitHub Actions bot.

Documentation:
- Add direct links in the README to the hosted web demo and latest downloadable release.

</details>